### PR TITLE
ci(renovate): add permissions to workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -43,6 +43,9 @@ concurrency:
 jobs:
   renovate:
     uses: ./.github/workflows/run-renovate.yaml
+    permissions:
+      contents: read
+      pull-requests: write
     with:
       runner: ubuntu-latest
       configuration-file: .github/renovate-bot.json5


### PR DESCRIPTION
Add `contents: read` and `pull-requests: write` permissions block to renovate workflow.